### PR TITLE
resetting targetted framework version to 4.5.2

### DIFF
--- a/AuthenticationExample/App.config
+++ b/AuthenticationExample/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/AuthenticationExample/AuthenticationExample.csproj
+++ b/AuthenticationExample/AuthenticationExample.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>AuthenticationExample</RootNamespace>
     <AssemblyName>AuthenticationExample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/AuthenticationExample/AuthenticationExample.csproj
+++ b/AuthenticationExample/AuthenticationExample.csproj
@@ -89,8 +89,8 @@
     <Reference Include="EventHook, Version=1.4.105.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EventHook.1.4.105\lib\net45\EventHook.dll</HintPath>
     </Reference>
-    <Reference Include="Finsemble, Version=3.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Finsemble.3.9.0\lib\net452\Finsemble.dll</HintPath>
+    <Reference Include="Finsemble, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Finsemble.3.10.0\lib\net452\Finsemble.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>

--- a/AuthenticationExample/Properties/Settings.Designer.cs
+++ b/AuthenticationExample/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AuthenticationExample.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/AuthenticationExample/packages.config
+++ b/AuthenticationExample/packages.config
@@ -14,18 +14,18 @@
   <package id="OpenFin.WPF" version="8.1.3" targetFramework="net461" />
   <package id="OpenfinDesktop" version="8.1.3" targetFramework="net452" />
   <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
-  <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Security" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Net.Security" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />

--- a/AuthenticationExample/packages.config
+++ b/AuthenticationExample/packages.config
@@ -3,7 +3,7 @@
   <package id="DotNetZip" version="1.13.0" targetFramework="net461" />
   <package id="EngineIoClientDotNet" version="1.0.7" targetFramework="net461" />
   <package id="EventHook" version="1.4.105" targetFramework="net461" />
-  <package id="Finsemble" version="3.9.0" targetFramework="net461" />
+  <package id="Finsemble" version="3.10.0" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net461" />

--- a/WPFExample/App.config
+++ b/WPFExample/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/WPFExample/Properties/Settings.Designer.cs
+++ b/WPFExample/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace FinsembleWPFDemo.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/WPFExample/WPFExample.csproj
+++ b/WPFExample/WPFExample.csproj
@@ -89,8 +89,8 @@
     <Reference Include="EventHook, Version=1.4.105.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EventHook.1.4.105\lib\net45\EventHook.dll</HintPath>
     </Reference>
-    <Reference Include="Finsemble, Version=3.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Finsemble.3.9.0\lib\net452\Finsemble.dll</HintPath>
+    <Reference Include="Finsemble, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Finsemble.3.10.0\lib\net452\Finsemble.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>

--- a/WPFExample/WPFExample.csproj
+++ b/WPFExample/WPFExample.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>FinsembleWPFDemo</RootNamespace>
     <AssemblyName>FinsembleWPFDemo</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -131,7 +131,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Specialized, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Specialized.4.3.0\lib\net46\System.Collections.Specialized.dll</HintPath>

--- a/WPFExample/packages.config
+++ b/WPFExample/packages.config
@@ -1,7 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetZip" version="1.13.0" targetFramework="net452" />
-  <package id="log4net" version="2.0.8" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net452" />
+  <package id="EngineIoClientDotNet" version="1.0.7" targetFramework="net452" />
+  <package id="EventHook" version="1.4.105" targetFramework="net452" />
   <package id="Finsemble" version="3.10.0" targetFramework="net452" />
+  <package id="log4net" version="2.0.8" targetFramework="net452" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net452" />
+  <package id="Nito.AsyncEx" version="4.0.1" targetFramework="net452" />
+  <package id="Openfin.WinForm" version="8.1.3" targetFramework="net452" />
+  <package id="OpenFin.WPF" version="8.1.3" targetFramework="net452" />
+  <package id="OpenfinDesktop" version="8.1.3" targetFramework="net452" />
+  <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net452" />
+  <package id="WebSocket4Net" version="0.15.2" targetFramework="net452" />
 </packages>

--- a/WPFExample/packages.config
+++ b/WPFExample/packages.config
@@ -3,5 +3,5 @@
   <package id="DotNetZip" version="1.13.0" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net452" />
-  <package id="Finsemble" version="3.9.0" targetFramework="net461" />
+  <package id="Finsemble" version="3.10.0" targetFramework="net452" />
 </packages>

--- a/WindowlessExample/App.config
+++ b/WindowlessExample/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/WindowlessExample/Properties/Settings.Designer.cs
+++ b/WindowlessExample/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WindowlessExample.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/WindowlessExample/WindowlessExample.csproj
+++ b/WindowlessExample/WindowlessExample.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WindowlessExample</RootNamespace>
     <AssemblyName>WindowlessExample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/WindowlessExample/WindowlessExample.csproj
+++ b/WindowlessExample/WindowlessExample.csproj
@@ -89,8 +89,8 @@
     <Reference Include="EventHook, Version=1.4.105.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EventHook.1.4.105\lib\net45\EventHook.dll</HintPath>
     </Reference>
-    <Reference Include="Finsemble, Version=3.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Finsemble.3.9.0\lib\net452\Finsemble.dll</HintPath>
+    <Reference Include="Finsemble, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Finsemble.3.10.0\lib\net452\Finsemble.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>

--- a/WindowlessExample/packages.config
+++ b/WindowlessExample/packages.config
@@ -14,18 +14,18 @@
   <package id="OpenFin.WPF" version="8.1.3" targetFramework="net461" />
   <package id="OpenfinDesktop" version="8.1.3" targetFramework="net452" />
   <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
-  <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Security" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Net.Security" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />

--- a/WindowlessExample/packages.config
+++ b/WindowlessExample/packages.config
@@ -3,7 +3,7 @@
   <package id="DotNetZip" version="1.13.0" targetFramework="net461" />
   <package id="EngineIoClientDotNet" version="1.0.7" targetFramework="net461" />
   <package id="EventHook" version="1.4.105" targetFramework="net461" />
-  <package id="Finsemble" version="3.9.0" targetFramework="net461" />
+  <package id="Finsemble" version="3.10.0" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net461" />


### PR DESCRIPTION
Although the Finsemble DLL was updated to target .Net >= 4.5.2 (after accidentally pushing tha upto 4.6.1), the example projects are still targetting the newer version in error. 

As many of our clients are repurposing old .Net apps  to work in FInsemble, before replacing them with HTML5, we wish to maintain the compatability with .Net 4.5.2.