### PR TITLE
15197 Check a value is selected before trying to stringify it

### DIFF
--- a/WPFExample/MainWindow.xaml.cs
+++ b/WPFExample/MainWindow.xaml.cs
@@ -23,11 +23,14 @@ namespace WPFExample
 
 		private void SpawnComponent_Click(object sender, RoutedEventArgs e)
 		{
-			string componentName = ComponentSelect.SelectedValue.ToString();
-			FSBL.RPC("LauncherClient.spawn", new List<JToken> {
-				componentName,
-				new JObject { ["addToWorkspace"] = true }
-			}, (s, a) => { });
+            object selected = ComponentSelect.SelectedValue;
+            if (selected != null) {
+                string componentName = selected.ToString();
+                FSBL.RPC("LauncherClient.spawn", new List<JToken> {
+                    componentName,
+                    new JObject { ["addToWorkspace"] = true }
+                }, (s, a) => { });
+            }
 		}
 
 		private void Send_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/21/cards/15197/details/

The WPFExample crashes if you fail to select a component name, before hitting spawn component. This PR adds an if statement to check something is selected, ignoring the click otherwise.